### PR TITLE
Add option to auto center text and change line spacing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ docker run -d \
     -e FONT_COLOR="white" \
     -e X_COORD="300" \
     -e Y_COORD="150" \
+    -e CENTER_TEXT="false" \
+    -e LINE_SPACING="10"
     -e START_TIME="5" \
     -e END_TIME="13" \
     -e UID="1000" \
@@ -66,6 +68,8 @@ docker run -d \
       - FONT_COLOR=white
       - X_COORD=300
       - Y_COORD=150
+      - CENTER_TEXT=false
+      - LINE_SPACING=10
       - START_TIME=5
       - END_TIME=13
       - UID=1000
@@ -91,6 +95,8 @@ docker run -d \
 | -e FONT_COLOR               | (Required) Color of the generated text. Usable strings can be found here: [color-syntax](https://ffmpeg.org/ffmpeg-utils.html#color-syntax)                                                                                                                                                                                                                       |
 | -e X_COORD                  | (Required) The x coordinate for the top-left of the text area in pixels.                                                                                                                                                                                                                                                                                          |
 | -e Y_COORD                  | (Required) The y coordinate for the top-left of the text area in pixels.                                                                                                                                                                                                                                                                                          |
+| -e CENTER_TEXT              | (Optional) If set to "true" it centers the text on the screen. This will override the X and Y coordinates. Set to "false" to use X and Y coordinates. If ommited it will default to "false".                                                                                                                                                                      |
+| -e LINE_SPACING             | (Optional) Sets the spacing between each movie title line in pixels. If ommited it will default to 10 pixels.                                                                                                                                                                                                                                                     |
 | -e START_TIME               | (Required) The start time (in seconds) the text will appear in the video.                                                                                                                                                                                                                                                                                         |
 | -e END_TIME                 | (Required) The end time (in seconds) the text will appear in the video.                                                                                                                                                                                                                                                                                           |
 | -v /host/config/dir:/config | This is the mount points for the config directory. This is where the input file and font file need to be placed and where the log in intermediate text file will be generated. The left of the colon will be the path to the config on the host machine. The right of the colon will be the path of the config in the container and should always be **/config**. |

--- a/app-docker.py
+++ b/app-docker.py
@@ -33,7 +33,7 @@ x = int(os.getenv("X_COORD", 300))
 y = int(os.getenv("Y_COORD", 150))
 startTime = int(os.getenv("START_TIME",5))
 endTime = int(os.getenv("END_TIME", 13))
-centerText = (os.getenv(CENTER_TEXT), False)
+centerText = os.getenv("CENTER_TEXT", "false").lower() == "true"
 lineSpacing = int(os.getenv("LINE_SPACING", 10))
 
 if centerText:

--- a/app-docker.py
+++ b/app-docker.py
@@ -33,6 +33,12 @@ x = int(os.getenv("X_COORD", 300))
 y = int(os.getenv("Y_COORD", 150))
 startTime = int(os.getenv("START_TIME",5))
 endTime = int(os.getenv("END_TIME", 13))
+centerText = (os.getenv(CENTER_TEXT), False)
+lineSpacing = int(os.getenv("LINE_SPACING", 10))
+
+if centerText:
+    x = "(w-text_w)/2"
+    y = "(h-text_h)/2"
 
 logging.basicConfig(
     level=logging.INFO,
@@ -87,7 +93,7 @@ def ical_to_filtered_list(ical_data):
 def write_to_file(events, filename):
     with open(filename, "w") as file:
         for summary, dtstart in events:
-            file.write(f"{dtstart} - {summary}\n\n") # You can edit this line to format how you desire. {dtstart} is the release date and {summary} is the movie title.
+            file.write(f"{dtstart} - {summary}\n") # You can edit this line to format how you desire. {dtstart} is the release date and {summary} is the movie title.
     logging.info(f"Wrote {len(events)} events to {filename}")
 
 # This is the running of the ffmpeg command. It takes in the intermediate file and overlays the text onto the video.
@@ -95,7 +101,7 @@ def write_to_file(events, filename):
 def run_ffmpeg_command():
     command = (
         f"{ffmpegLoc}/ffmpeg -y -i {inputFile} -vf "
-        f"\"drawtext=textfile={textFile}:fontfile={fontFile}:fontsize={fontSize}:fontcolor={fontColor}:x={x}:y={y}:enable='between(t,{startTime},{endTime})'\" "
+        f"\"drawtext=textfile={textFile}:fontfile={fontFile}:fontsize={fontSize}:fontcolor={fontColor}:x={x}:y={y}:line_spacing={lineSpacing}:enable='between(t,{startTime},{endTime})'\" "
         f"-c:a copy {outputFile}"
     )
     logging.info(f"FFmpeg command: {command}")

--- a/app.py
+++ b/app.py
@@ -40,6 +40,12 @@ x = 300
 y = 150
 startTime = 5
 endTime = 13
+lineSpacing = 10
+centerText = False
+
+if centerText:
+    x = "(w-text_w)/2"
+    y = "(h-text_h)/2"
 
 # Fetching of ical file
 
@@ -85,7 +91,7 @@ def ical_to_filtered_list(ical_data):
 def write_to_file(events, filename):
     with open(filename, "w") as file:
         for summary, dtstart in events:
-            file.write(f"{dtstart} - {summary}\n\n") # You can edit this line to format how you desire. {dtstart} is the release date and {summary} is the movie title.
+            file.write(f"{dtstart} - {summary}\n") # You can edit this line to format how you desire. {dtstart} is the release date and {summary} is the movie title.
     logging.info(f"Wrote {len(events)} events to {filename}")
 
 # This is the running of the ffmpeg command. It takes in the intermediate file and overlays the text onto the video.
@@ -93,7 +99,7 @@ def write_to_file(events, filename):
 def run_ffmpeg_command():
     command = (
         f"{ffmpegLoc}ffmpeg -y -i {inputFile} -vf "
-        f"\"drawtext=textfile={textFile}:fontfile={fontFile}:fontsize={fontSize}:fontcolor={fontColor}:x={x}:y={y}:enable='between(t,{startTime},{endTime})'\" "
+        f"\"drawtext=textfile={textFile}:fontfile={fontFile}:fontsize={fontSize}:fontcolor={fontColor}:x={x}:y={y}:line_spacing={lineSpacing}:enable='between(t,{startTime},{endTime})'\" "
         f"-c:a copy {outputFile}"
     )
     subprocess.run(command, shell=True, check=True)


### PR DESCRIPTION
I found setting the X & Y coords to be cumbersome to set up.  Set values also didn't work for movies with very long titles. 

I've added an env var that allows you to set centerText to auto center everything. To allow the user to fine tune the appearance of this I also added an optional env var to change the line spacing as desired. For now I defaulted it to 10.